### PR TITLE
Fix incorrect environment variable format in genv run command

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -34,13 +34,15 @@ func run(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to read .env file: %w", err)
 	}
-	envs, err := dotenv.Marshal(envMap)
-	if err != nil {
-		return fmt.Errorf("failed to marshal environment variables: %w", err)
+
+	for k, v := range envMap {
+		if err := os.Setenv(k, v); err != nil {
+			return fmt.Errorf("failed to set environment variable %s: %w", k, err)
+		}
 	}
 
 	command := exec.Command(args[0], args[1:]...)
-	command.Env = append(os.Environ(), envs)
+	command.Env = os.Environ()
 	command.Stdout = os.Stdout
 	command.Stderr = os.Stderr
 


### PR DESCRIPTION
### Problem
The `genv run` command was setting environment variables in an incorrect format.
The previous implementation used `dotenv.Marshal()` which returns environment variables as dotenv-formatted strings (e.g., `KEY="value"`), and then appended these strings directly to `command.Env`. This caused environment variables to be set in an unintended format, making them unusable by the executed command.

### Solution
Changed the implementation to:

- Use `os.Setenv()` to properly set each environment variable from the envfile into the current process environment
- Use `os.Environ()` to get the complete environment (including both existing and newly set variables) for the executed command

This ensures that environment variables are correctly formatted and accessible to the command being executed.