### PR TITLE
refactor run command

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"os/exec"
 
+	"github.com/mrtc0/genv"
 	"github.com/mrtc0/genv/dotenv"
 	"github.com/spf13/cobra"
 )
@@ -35,18 +35,18 @@ func run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to read .env file: %w", err)
 	}
 
-	for k, v := range envMap {
-		if err := os.Setenv(k, v); err != nil {
-			return fmt.Errorf("failed to set environment variable %s: %w", k, err)
-		}
+	runner, err := genv.NewCommandRunner(genv.CommandRunnerConfig{
+		Name:   args[0],
+		Args:   args[1:],
+		Envs:   envMap,
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create command runner: %w", err)
 	}
 
-	command := exec.Command(args[0], args[1:]...)
-	command.Env = os.Environ()
-	command.Stdout = os.Stdout
-	command.Stderr = os.Stderr
-
-	if err := command.Run(); err != nil {
+	if err := runner.Run(); err != nil {
 		return fmt.Errorf("failed to run command: %w", err)
 	}
 	return nil

--- a/command_runner.go
+++ b/command_runner.go
@@ -1,0 +1,44 @@
+package genv
+
+import (
+	"io"
+	"os"
+	"os/exec"
+)
+
+type CommandRunner interface {
+	// Run executes the command with the provided environment variables.
+	Run() error
+}
+
+type commandRunner struct {
+	cmd *exec.Cmd
+}
+
+type CommandRunnerConfig struct {
+	Name   string
+	Args   []string
+	Envs   map[string]string
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+func NewCommandRunner(cfg CommandRunnerConfig) (CommandRunner, error) {
+	envs := make([]string, 0, len(cfg.Envs))
+	for k, v := range cfg.Envs {
+		envs = append(envs, k+"="+v)
+	}
+
+	command := exec.Command(cfg.Name, cfg.Args...)
+	command.Env = append(os.Environ(), envs...)
+	command.Stdout = cfg.Stdout
+	command.Stderr = cfg.Stderr
+
+	return &commandRunner{
+		cmd: command,
+	}, nil
+}
+
+func (c *commandRunner) Run() error {
+	return c.cmd.Run()
+}

--- a/command_runner_test.go
+++ b/command_runner_test.go
@@ -1,0 +1,36 @@
+package genv_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/mrtc0/genv"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommandRunner_Run(t *testing.T) {
+	t.Parallel()
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	runner, err := genv.NewCommandRunner(genv.CommandRunnerConfig{
+		Name: "sh",
+		Args: []string{"-c", "echo Hello \"$ENV_VAR_1\" \"$ENV_VAR_2\""},
+		Envs: map[string]string{
+			"ENV_VAR_1": "Value1",
+			"ENV_VAR_2": "Value2",
+		},
+		Stdout: stdout,
+		Stderr: stderr,
+	})
+	assert.NoError(t, err)
+
+	err = runner.Run()
+	assert.NoError(t, err)
+
+	expectedOutput := "Hello Value1 Value2\n"
+	assert.Equal(t, expectedOutput, stdout.String())
+
+	assert.Empty(t, stderr.String())
+}


### PR DESCRIPTION
This change introduces a CommandRunner abstraction layer for executing commands run by the `run` command, enabling testability.

Regarding the changes #10, @shirakiya advised me about the potential side effects of `os.Setenv` on subsequent operations. Therefore, we've reverted to the original method of appending to `command.Env`.

